### PR TITLE
Cloud9 Scripts

### DIFF
--- a/scripts/c9setup.sh
+++ b/scripts/c9setup.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Simple setup script for getting a Cloud9 workspace ready for doing dev work
+# on the ReUse website.
+echo
+echo "1 - UPGRADE PHP"
+
+# Add the required repository
+echo -n "     Adding ondrej/php repository... "
+sudo add-apt-repository ppa:ondrej/php -y >/dev/null 2>&1
+echo "DONE"
+
+# update to pull in changes from the new ondrej/php repository
+echo -n "     Updating apt-get... "
+sudo apt-get update >/dev/null 2>&1
+echo "DONE"
+
+# install php5.6 and all of its required dependencies
+echo -n "     Installing updated php and dependencies... "
+sudo apt-get install php5.6 php5.6-mbstring php5.6-mcrypt php5.6-mysql php5.6-xml -y >/dev/null 2>&1
+echo "DONE"
+
+# disable apache 5.5 module
+echo -n "     Disabling old apache 5 module... "
+sudo a2dismod php5 >/dev/null 2>&1
+echo "DONE"
+
+# enable apache 5.6 module
+echo -n "     Enabling apache 5.6 module... "
+sudo a2enmod php5.6 >/dev/null 2>&1
+echo "DONE"
+
+# restart the apache service
+echo -n "     Restarting the apache service... "
+sudo service apache2 restart >/dev/null 2>&1
+echo "DONE"
+
+echo
+echo "2 - ENABLE MYSQL"
+
+# enable the mysql server
+echo -n "     Enabling the mysql server... "
+mysql-ctl start >/dev/null 2>&1
+echo "DONE"
+
+echo
+echo "3 - UPDATE APACHE DOCUMENT ROOT"
+echo -n "     Updating apache config file... "
+sudo sed -i -e 's/DocumentRoot \/home\/ubuntu\/workspace/DocumentRoot \/home\/ubuntu\/workspace\/public_html/g' /etc/apache2/sites-enabled/001-cloud9.conf
+echo "DONE"

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -3,7 +3,12 @@
 # 1) Validate passed in arguments
 
 if [ "$#" -ne 1 ]; then
-    export API_ADDR="localhost:8080"
+    # export localhost address dependent on environment
+    if [ -z ${C9_USER} ]; then
+        export API_ADDR="localhost:8080"
+    else
+        export API_ADDR="localhost:56565"
+    fi
 else
     export API_ADDR=$1
 fi
@@ -21,7 +26,11 @@ else
 fi
 
 echo -n "Checking if MySQL server is running...   "
-mysqladmin --login-path=local status >/dev/null 2>&1
+if [ -z ${C9_USER} ]; then
+    mysqladmin --login-path=local status >/dev/null 2>&1
+else
+    sudo mysqladmin status >/dev/null 2>&1
+fi
 
 if [ "$?" -ne 0 ]; then
     echo "MySQL server not running!"


### PR DESCRIPTION
Includes a simple setup script for getting a Cloud9 LAMP stack ready to run the ReUse application.  also updates the runtests.sh script to handle the differences between a cloud9 and local environment.  

In theory this should allow for both local and cloud dev using Cloud9.  @tylerforrester this should make getting setup REALLY easy.

I _didn't_ include a README but will do so at some point.  Just wanted to get this out there.  